### PR TITLE
Correct the spelling of macOS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ ipanema -I path/to/your.ipa | head
 
 # Prequisite
 
-- OSX/macOS
+- macOS/macOS
 
 # Install
 


### PR DESCRIPTION
This pull request corrects the spelling of **macOS** 🤓
http://www.apple.com/macos/sierra/

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
